### PR TITLE
spdk: do not half-close the connection before reading the response

### DIFF
--- a/spdk/jsonrpc.go
+++ b/spdk/jsonrpc.go
@@ -164,16 +164,6 @@ func (r *Client) communicate(buf []byte) io.Reader {
 	if err != nil {
 		log.Fatal(err)
 	}
-	// close
-	switch conn := conn.(type) {
-	case *net.TCPConn:
-		err = conn.CloseWrite()
-	case *net.UnixConn:
-		err = conn.CloseWrite()
-	}
-	if err != nil {
-		log.Fatal(err)
-	}
 	// read
 	return bufio.NewReader(conn)
 }


### PR DESCRIPTION
Client.communicate() called conn.CloseWrite() immediately after writing the request and before reading the reply, half-closing the write side of the socket.

SPDK's JSON-RPC server marks conn->closed when it sees the client's write-half EOF. Historically that was harmless because jsonrpc_server_send_response queued the reply regardless. SPDK commit 274643bf27f2d8ac04d8326e90c17c62cd31a614 ("lib/jsonrpc: fix memory leak on closed connection") changed that: send_response now checks conn->closed and, when set, drops the reply instead of queuing it, logging "attempt to send response on closed connection".

For asynchronous RPCs whose reply is produced later by a poller (e.g. nvmf_create_transport, bdev_nvme_attach_controller), the client's half-close is processed before the reply is ready, so with that change the server drops the reply and the client reads a spurious EOF even though the operation succeeded on the target.

A JSON-RPC request is self-delimiting (a single complete JSON object), so half-closing the write side is unnecessary to frame the request. Remove the CloseWrite and keep the connection fully open until the single response is read.