### PR TITLE
fix: migrate golangci-lint config to v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,60 +1,50 @@
-# This file contains all available configuration options
-# with their default values.
-
-# options for analysis running
-run:
-
-# output configuration options
-output:
-  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
-  format: colored-line-number
-
-linters-settings:
-  funlen:
-    lines: 150
-    statements: 120
-  dupl:
-    threshold: 200
-  gocognit:
-    min-complexity: 32
-
+version: "2"
 linters:
   enable:
     - bodyclose
     - dogsled
-    - errcheck
-    - exportloopref
     - funlen
     - gochecknoinits
     - gocognit
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
-    - goimports
     - gosec
-    - gosimple
-    - govet
-    - ineffassign
     - misspell
     - nakedret
     - prealloc
     - revive
     - staticcheck
-    - stylecheck
     - unconvert
     - unparam
     - whitespace
-
+  settings:
+    dupl:
+      threshold: 200
+    funlen:
+      lines: 150
+      statements: 120
+    gocognit:
+      min-complexity: 32
+    gosec:
+      excludes:
+        - G115
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  # Independently from option `exclude` we use default exclude patterns,
-  # it can be disabled by this option. To list all
-  # excluded by default patterns execute `golangci-lint run --help`.
-  # Default value for this option is true.
-  exclude-use-default: false
-
-  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
   max-issues-per-linter: 0
-
-  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
   max-same-issues: 0
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/spdk/jsonrpc.go
+++ b/spdk/jsonrpc.go
@@ -31,6 +31,9 @@ var (
 	ErrUnexpectedSpdkCallResult = status.Error(codes.FailedPrecondition, "Unexpected SPDK call result.")
 )
 
+// unixProtocol is the network name used for unix domain socket connections
+const unixProtocol = "unix"
+
 // JSONRPC represents an interface to execute JSON RPC to SPDK
 type JSONRPC interface {
 	GetID() uint64
@@ -59,7 +62,7 @@ func NewClient(socketPath string) *Client {
 	}
 	protocol := "tcp"
 	if _, _, err := net.SplitHostPort(socketPath); err != nil {
-		protocol = "unix"
+		protocol = unixProtocol
 	}
 	log.Printf("Connection to SPDK will be via: %s detected from %s", protocol, socketPath)
 	return &Client{
@@ -93,7 +96,7 @@ func (r *Client) StartUnixListener() net.Listener {
 	if err := os.RemoveAll(r.socket); err != nil {
 		log.Fatal(err)
 	}
-	ln, err := net.Listen("unix", r.socket)
+	ln, err := net.Listen(unixProtocol, r.socket)
 	if err != nil {
 		log.Fatal("listen error:", err)
 	}
@@ -128,7 +131,7 @@ func (r *Client) Call(ctx context.Context, method string, args, result interface
 
 	log.Printf("Sending to SPDK: %s", data)
 
-	resp, _ := r.communicate(data)
+	resp := r.communicate(data)
 
 	var response RPCResponse
 	err = json.NewDecoder(resp).Decode(&response)
@@ -150,7 +153,7 @@ func (r *Client) Call(ctx context.Context, method string, args, result interface
 	return nil
 }
 
-func (r *Client) communicate(buf []byte) (io.Reader, error) {
+func (r *Client) communicate(buf []byte) io.Reader {
 	// connect
 	conn, err := net.Dial(r.transport, r.socket)
 	if err != nil {
@@ -160,7 +163,6 @@ func (r *Client) communicate(buf []byte) (io.Reader, error) {
 	_, err = conn.Write(buf)
 	if err != nil {
 		log.Fatal(err)
-		return nil, err
 	}
 	// close
 	switch conn := conn.(type) {
@@ -171,8 +173,7 @@ func (r *Client) communicate(buf []byte) (io.Reader, error) {
 	}
 	if err != nil {
 		log.Fatal(err)
-		return nil, err
 	}
 	// read
-	return bufio.NewReader(conn), nil
+	return bufio.NewReader(conn)
 }

--- a/spdk/jsonrpc_test.go
+++ b/spdk/jsonrpc_test.go
@@ -19,7 +19,7 @@ func TestSpdk_NewClient(t *testing.T) {
 	}{
 		"testing unix": {
 			"/var/tmp/spdk.sock",
-			"unix",
+			unixProtocol,
 			false,
 		},
 		"testing tcp": {
@@ -34,7 +34,7 @@ func TestSpdk_NewClient(t *testing.T) {
 		},
 		"testing nonsense assuming unix": {
 			"nonsense",
-			"unix",
+			unixProtocol,
 			false,
 		},
 	}


### PR DESCRIPTION
migrate golangci-lint config to v2 to eleiminate CI CD errors

this PR mirrors #76