### PR TITLE
fix(jsonrpc): return dial/write errors instead of log.Fatal

### DIFF
--- a/spdk/jsonrpc.go
+++ b/spdk/jsonrpc.go
@@ -131,7 +131,10 @@ func (r *Client) Call(ctx context.Context, method string, args, result interface
 
 	log.Printf("Sending to SPDK: %s", data)
 
-	resp := r.communicate(data)
+	resp, err := r.communicate(data)
+	if err != nil {
+		return fmt.Errorf("%s: %s", method, err)
+	}
 
 	var response RPCResponse
 	err = json.NewDecoder(resp).Decode(&response)
@@ -153,17 +156,17 @@ func (r *Client) Call(ctx context.Context, method string, args, result interface
 	return nil
 }
 
-func (r *Client) communicate(buf []byte) io.Reader {
+func (r *Client) communicate(buf []byte) (io.Reader, error) {
 	// connect
 	conn, err := net.Dial(r.transport, r.socket)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	// write
 	_, err = conn.Write(buf)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	// read
-	return bufio.NewReader(conn)
+	return bufio.NewReader(conn), nil
 }


### PR DESCRIPTION
communicate() called log.Fatal on a failed net.Dial or write, which runs os.Exit(1) and takes down the entire host process. When the SPDK socket is absent (backend not running), any RPC such as bdev_get_bdevs crashed the caller instead of surfacing a recoverable error.

Return the error from communicate() and propagate it through Call() so callers receive a normal error (for gRPC servers, a proper status) rather than a process exit.